### PR TITLE
Interval Argument

### DIFF
--- a/openj/__init__.py
+++ b/openj/__init__.py
@@ -11,7 +11,7 @@ from openj.api.card import card
 from openj.kanban import kanban
 from openj.db import init_app
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 
 def create_app(test_config=None):

--- a/openj/kanban.py
+++ b/openj/kanban.py
@@ -19,10 +19,11 @@ kanban = Blueprint("kanban", __name__)
 
 @kanban.route("/kanban")
 def index():
+    interval = request.args.get("interval")
     lanes = get_db().execute("SELECT * FROM lane").fetchall()
     cards = get_db().execute("SELECT * FROM card").fetchall()
     groups = {l["title"]: [c for c in cards if c["lane_id"] == l["id"]] for l in lanes}
-    return render_template("kanban.html", groups=groups)
+    return render_template("kanban.html", interval=interval, groups=groups)
 
 
 @kanban.route("/kanban/create", methods=("GET", "POST"))

--- a/openj/templates/base.htm
+++ b/openj/templates/base.htm
@@ -4,6 +4,9 @@
         <title>{% block title %}{% endblock %}</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% if interval %}
+        <meta http-equiv="refresh" content="{{ interval }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ url_for('static', filename='site.css') }}" />
     </head>
     <body>


### PR DESCRIPTION
### Description
Add a refresh interval argument, in seconds, that can be passed on the main '/kanban' endpoint and will force the page content to refresh. For example, a 30 second refresh interval would look as follows: `/kanban?interval=30`.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
